### PR TITLE
Feat/centralized usage improvements

### DIFF
--- a/src/ALL IN ONE USAGE EXAMPLE Problema5tipo2.ipynb
+++ b/src/ALL IN ONE USAGE EXAMPLE Problema5tipo2.ipynb
@@ -191,40 +191,47 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[debug] (lower, upper): (104.0, 1e+20)\n",
+      "[debug] (lower, upper): (80.0, 140.0)\n",
       "---\n",
-      "- Adjusting RHS to: 103.99\n",
-      "* Production model solved with objective: 5699.6\n",
-      "* Total benefit=5699.6\n",
-      "Production of A: 49.97999999999999\n",
+      "- Adjusting RHS to: 79.99\n",
+      "No solution found for RHS value: 79.99\n",
+      "---\n",
+      "- Adjusting RHS to: 140.01\n",
+      "* Production model solved with objective: 8200.5\n",
+      "* Total benefit=8200.5\n",
+      "Production of A: 100.0\n",
       "Production of B: 80.0\n",
-      "Production of C: 0.020000000000010232\n",
+      "Production of C: 0.01666666666665151\n",
       "---\n",
-      "- Adjusting RHS to: 79.0\n",
-      "* Production model solved with objective: 4700\n",
-      "* Total benefit=4700\n",
+      "- Adjusting RHS to: 172.0\n",
+      "* Production model solved with objective: 9800\n",
+      "* Total benefit=9800\n",
+      "Production of A: 100.0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 53.33333333333334\n",
+      "---\n",
+      "- Adjusting RHS to: 172.01\n",
+      "* Production model solved with objective: 9800.3\n",
+      "* Total benefit=9800.3\n",
+      "Production of A: 99.99000000000001\n",
+      "Production of B: 80.0\n",
+      "Production of C: 53.359999999999985\n",
+      "---\n",
+      "- Adjusting RHS to: 272.0\n",
+      "* Production model solved with objective: 12800\n",
+      "* Total benefit=12800\n",
       "Production of A: 0\n",
       "Production of B: 80.0\n",
-      "Production of C: 50.0\n",
+      "Production of C: 320.0\n",
       "---\n",
-      "- Adjusting RHS to: 78.99\n",
-      "* Production model solved with objective: 4699\n",
-      "* Total benefit=4699\n",
+      "- Adjusting RHS to: 272.01\n",
+      "* Production model solved with objective: 12800\n",
+      "* Total benefit=12800\n",
       "Production of A: 0\n",
       "Production of B: 80.0\n",
-      "Production of C: 49.966666666666654\n",
+      "Production of C: 320.0\n",
       "---\n",
-      "- Adjusting RHS to: 64.0\n",
-      "* Production model solved with objective: 3200\n",
-      "* Total benefit=3200\n",
-      "Production of A: 0\n",
-      "Production of B: 80.0\n",
-      "Production of C: 0\n",
-      "---\n",
-      "- Adjusting RHS to: 63.99\n",
-      "No solution found for RHS value: 63.99\n",
-      "---\n",
-      "- Adjusting RHS to: 160\n",
+      "- Adjusting RHS to: 110\n",
       "* Production model solved with objective: 5700\n",
       "* Total benefit=5700\n",
       "Production of A: 50.0\n",
@@ -236,7 +243,7 @@
    "source": [
     "from plot_kind.vm_vs_disp import VM\n",
     "# Usage of the iterate_over_rhs method\n",
-    "constraint_nameX = 'Disp_Equipo1'  # The name of the constraint X to analyze\n",
+    "constraint_nameX = 'Disp_Equipo3'  # The name of the constraint X to analyze\n",
     "\n",
     "vm = VM(mdl, products, production_vars)\n",
     "current_rhs_value, rhs_values, dual_values = vm.iterate(constraint_nameX)"
@@ -252,7 +259,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[debug] current_x_value: 160\n"
+      "[debug] current_x_value: 110\n"
      ]
     },
     {
@@ -427,17 +434,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[debug] (lower, upper): (-1e+20, 83.33333333333334)\n",
-      "* Production model solved with objective: 9167.77\n",
-      "* Total benefit=9167.77\n",
+      "[debug] (lower, upper): (29.999999999999993, 1e+20)\n",
+      "* Production model solved with objective: 4700\n",
+      "* Total benefit=4700\n",
       "Production of A: 0\n",
-      "Production of B: 110.0\n",
-      "Production of C: 0\n",
-      "* Production model solved with objective: 2500\n",
-      "* Total benefit=2500\n",
-      "Production of A: 50.0\n",
       "Production of B: 80.0\n",
-      "Production of C: 0\n",
+      "Production of C: 50.0\n",
+      "* Production model solved with objective: 4700\n",
+      "* Total benefit=4700\n",
+      "Production of A: 0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 50.0\n",
       "* Production model solved with objective: 5700\n",
       "* Total benefit=5700\n",
       "Production of A: 50.0\n",
@@ -448,7 +455,7 @@
    ],
    "source": [
     "from plot_kind.curva_of_cant_vs_precio import CurvaDeOferta\n",
-    "product_name = \"B\"\n",
+    "product_name = \"A\"\n",
     "curva_of = CurvaDeOferta(mdl, products, production_vars)\n",
     "current_price_value, prices, quantities = curva_of.iterate(product_name)"
    ]
@@ -463,7 +470,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[debug] current_x_value: 40\n"
+      "[debug] current_x_value: 50\n"
      ]
     },
     {
@@ -487,6 +494,497 @@
    ],
    "source": [
     "curva_of.plot(product_name, \"[$/u]\", \"[u/mes]\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae976daf",
+   "metadata": {},
+   "source": [
+    "# Desde una sola clase"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24e185e4",
+   "metadata": {},
+   "source": [
+    "## Cargar los datos y crear el modelo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d1f6c89d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model: guia5problematipo2\n",
+      " - number of variables: 3\n",
+      "   - binary=0, integer=0, continuous=3\n",
+      " - number of constraints: 9\n",
+      "   - linear=9\n",
+      " - parameters: defaults\n",
+      " - objective: none\n",
+      " - problem type is: LP\n",
+      "* Production model solved with objective: 5700\n",
+      "* Total benefit=5700\n",
+      "Production of A: 50.0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cargar los datos y obtener el modelo\n",
+    "from data_and_model_construction.data import create_data_dict\n",
+    "from data_and_model_construction.common_model import create_model, solve_model, print_model\n",
+    "\n",
+    "data = create_data_dict()\n",
+    "mdl, production_vars, products = create_model(data)\n",
+    "solve_model(mdl, production_vars, products)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "95ff856c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ### AUX\n",
+    "# product_name = \"B\"\n",
+    "# curva_of = CurvaDeOferta(mdl, products, production_vars)\n",
+    "# current_price_value, prices, quantities = curva_of.iterate(product_name)\n",
+    "# curva_of.plot(product_name, \"[$/u]\", \"[u/mes]\")\n",
+    "\n",
+    "# ### AUX\n",
+    "# constraint_name = 'Disp_Equipo3'  # The name of the constraint to analyze\n",
+    "# funcional = Funcional(mdl, products, production_vars)\n",
+    "# real_rhs_value, rhs_values, objective_values = funcional.iterate(constraint_name)\n",
+    "# funcional.plot(constraint_name, \"[hs/mes]\", \"[$/mes]\")\n",
+    "\n",
+    "# ### AUX\n",
+    "# constraint_nameX = 'Disp_Equipo3'  # The name of the constraint to analyze\n",
+    "# product_name=\"B\"\n",
+    "\n",
+    "# costo_op = CostoOportunidad(mdl, products, production_vars)\n",
+    "# current_rhs_value, rhs_values, dual_values = costo_op.iterate(constraint_nameX, product_name)\n",
+    "# costo_op.plot(constraint_nameX, product_name, \"[hs/mes]\", \"[$/un]\")\n",
+    "\n",
+    "# ### AUX\n",
+    "# constraint_nameX = 'Disp_Equipo1'  # The name of the constraint X to analyze\n",
+    "\n",
+    "# vm = VM(mdl, products, production_vars)\n",
+    "# current_rhs_value, rhs_values, dual_values = vm.iterate(constraint_nameX)\n",
+    "# vm.plot(constraint_nameX,\"[hs/mes]\", \"[$/un]\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "de6ac910",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from plot_kind.plot_kind_orchestrator import PlotKindOrchestrator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d0ed38c7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pko = PlotKindOrchestrator(mdl, products, production_vars)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ff42708b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[debug] (lower, upper): (29.999999999999993, 1e+20)\n",
+      "* Production model solved with objective: 4700\n",
+      "* Total benefit=4700\n",
+      "Production of A: 0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 50.0\n",
+      "* Production model solved with objective: 4700\n",
+      "* Total benefit=4700\n",
+      "Production of A: 0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 50.0\n",
+      "* Production model solved with objective: 5700\n",
+      "* Total benefit=5700\n",
+      "Production of A: 50.0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 0\n",
+      "[debug] current_x_value: 50\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 2000x1000 with 0 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(50, [0, 29.999999999999993, 29.999999999999993, 50], [0, 0, 50.0, 50.0])"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pko.curva_de_oferta(\"A\", \"[$/u]\", \"[u/mes]\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "09c1c202",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "---Initial lower bound: 80.0\n",
+      "---\n",
+      "- Adjusting RHS to: 80.0\n",
+      "* Production model solved with objective: 3200\n",
+      "* Total benefit=3200\n",
+      "Production of A: 0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 0\n",
+      "---Initial upper bound: 140.0\n",
+      "---\n",
+      "- Adjusting RHS to: 140.0\n",
+      "* Production model solved with objective: 8200\n",
+      "* Total benefit=8200\n",
+      "Production of A: 100.0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 0\n",
+      "---\n",
+      "- Adjusting RHS to: 79.99\n",
+      "No solution found for RHS value: 79.99\n",
+      "---\n",
+      "- Adjusting RHS to: 140.01\n",
+      "* Production model solved with objective: 8200.5\n",
+      "* Total benefit=8200.5\n",
+      "Production of A: 100.0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 0.01666666666665151\n",
+      "---\n",
+      "- Adjusting RHS to: 172.0\n",
+      "* Production model solved with objective: 9800\n",
+      "* Total benefit=9800\n",
+      "Production of A: 100.0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 53.33333333333334\n",
+      "---\n",
+      "- Adjusting RHS to: 172.01\n",
+      "* Production model solved with objective: 9800.3\n",
+      "* Total benefit=9800.3\n",
+      "Production of A: 99.99000000000001\n",
+      "Production of B: 80.0\n",
+      "Production of C: 53.359999999999985\n",
+      "---\n",
+      "- Adjusting RHS to: 272.0\n",
+      "* Production model solved with objective: 12800\n",
+      "* Total benefit=12800\n",
+      "Production of A: 0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 320.0\n",
+      "---\n",
+      "- Adjusting RHS to: 272.01\n",
+      "* Production model solved with objective: 12800\n",
+      "* Total benefit=12800\n",
+      "Production of A: 0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 320.0\n",
+      "---\n",
+      "- Adjusting RHS to: 110\n",
+      "* Production model solved with objective: 5700\n",
+      "* Total benefit=5700\n",
+      "Production of A: 50.0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 0\n",
+      "[debug] pairs [(110, 5700.0), (80.0, 3200.0), (140.0, 8200.0), (172.0, 9800.0), (272.0, 12800.0)]\n",
+      "[debug] pairs [(80.0, 3200.0), (110, 5700.0), (140.0, 8200.0), (172.0, 9800.0), (272.0, 12800.0)]\n",
+      "[debug] new_rhs [80.0, 110, 140.0, 172.0, 272.0]\n",
+      "[debug] new_dual [3200.0, 5700.0, 8200.0, 9800.0, 12800.0]\n",
+      "[debug] current_x_value: 110\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 2000x1000 with 0 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(110,\n",
+       " [110, 80.0, 140.0, 172.0, 272.0],\n",
+       " [5700.0, 3200.0, 8200.0, 9800.0, 12800.0])"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pko.funcional('Disp_Equipo3', \"[hs/mes]\", \"[$/mes]\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fd02ccf1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Demanda mínima encontrada para el producto B.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[debug] (lower, upper): (80.0, 140.0)\n",
+      "---\n",
+      "- Adjusting RHS to: 79.99\n",
+      "No solution found for RHS value: 79.99\n",
+      "---\n",
+      "- Adjusting RHS to: 140.01\n",
+      "* Production model solved with objective: 8200.5\n",
+      "* Total benefit=8200.5\n",
+      "Production of A: 100.0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 0.01666666666665151\n",
+      "---\n",
+      "- Adjusting RHS to: 172.0\n",
+      "* Production model solved with objective: 9800\n",
+      "* Total benefit=9800\n",
+      "Production of A: 100.0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 53.33333333333334\n",
+      "---\n",
+      "- Adjusting RHS to: 172.01\n",
+      "* Production model solved with objective: 9800.3\n",
+      "* Total benefit=9800.3\n",
+      "Production of A: 99.99000000000001\n",
+      "Production of B: 80.0\n",
+      "Production of C: 53.359999999999985\n",
+      "---\n",
+      "- Adjusting RHS to: 272.0\n",
+      "* Production model solved with objective: 12800\n",
+      "* Total benefit=12800\n",
+      "Production of A: 0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 320.0\n",
+      "---\n",
+      "- Adjusting RHS to: 272.01\n",
+      "* Production model solved with objective: 12800\n",
+      "* Total benefit=12800\n",
+      "Production of A: 0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 320.0\n",
+      "---\n",
+      "- Adjusting RHS to: 110\n",
+      "* Production model solved with objective: 5700\n",
+      "* Total benefit=5700\n",
+      "Production of A: 50.0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 0\n",
+      "[debug] current_x_value: 110\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 2000x1000 with 0 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(110,\n",
+       " [80.0, 110, 140.0, 140.0, 172.0, 172.0, 272.0, 272.0],\n",
+       " [43.33333333333334,\n",
+       "  43.33333333333334,\n",
+       "  43.33333333333334,\n",
+       "  10.0,\n",
+       "  10.0,\n",
+       "  22.0,\n",
+       "  22.0,\n",
+       "  40.0])"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pko.costo_oportunidad('Disp_Equipo3', \"B\", \"[hs/mes]\", \"[$/un]\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f9fd93ea",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[debug] (lower, upper): (80.0, 140.0)\n",
+      "---\n",
+      "- Adjusting RHS to: 79.99\n",
+      "No solution found for RHS value: 79.99\n",
+      "---\n",
+      "- Adjusting RHS to: 140.01\n",
+      "* Production model solved with objective: 8200.5\n",
+      "* Total benefit=8200.5\n",
+      "Production of A: 100.0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 0.01666666666665151\n",
+      "---\n",
+      "- Adjusting RHS to: 172.0\n",
+      "* Production model solved with objective: 9800\n",
+      "* Total benefit=9800\n",
+      "Production of A: 100.0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 53.33333333333334\n",
+      "---\n",
+      "- Adjusting RHS to: 172.01\n",
+      "* Production model solved with objective: 9800.3\n",
+      "* Total benefit=9800.3\n",
+      "Production of A: 99.99000000000001\n",
+      "Production of B: 80.0\n",
+      "Production of C: 53.359999999999985\n",
+      "---\n",
+      "- Adjusting RHS to: 272.0\n",
+      "* Production model solved with objective: 12800\n",
+      "* Total benefit=12800\n",
+      "Production of A: 0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 320.0\n",
+      "---\n",
+      "- Adjusting RHS to: 272.01\n",
+      "* Production model solved with objective: 12800\n",
+      "* Total benefit=12800\n",
+      "Production of A: 0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 320.0\n",
+      "---\n",
+      "- Adjusting RHS to: 110\n",
+      "* Production model solved with objective: 5700\n",
+      "* Total benefit=5700\n",
+      "Production of A: 50.0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 0\n",
+      "[debug] current_x_value: 110\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 2000x1000 with 0 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(110,\n",
+       " [80.0, 110, 140.0, 140.0, 172.0, 172.0, 272.0, 272.0],\n",
+       " [83.33333333333334,\n",
+       "  83.33333333333334,\n",
+       "  83.33333333333334,\n",
+       "  50.0,\n",
+       "  50.0,\n",
+       "  30.0,\n",
+       "  30.0,\n",
+       "  0])"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pko.vm('Disp_Equipo3', \"[hs/mes]\", \"[$/un]\")"
    ]
   }
  ],

--- a/src/ALL IN ONE USAGE EXAMPLE Problema5tipo2.ipynb
+++ b/src/ALL IN ONE USAGE EXAMPLE Problema5tipo2.ipynb
@@ -1,0 +1,612 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "4c82064c",
+   "metadata": {},
+   "source": [
+    "## Costo oportunidad"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5f64678b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model: guia5problematipo2\n",
+      " - number of variables: 3\n",
+      "   - binary=0, integer=0, continuous=3\n",
+      " - number of constraints: 9\n",
+      "   - linear=9\n",
+      " - parameters: defaults\n",
+      " - objective: none\n",
+      " - problem type is: LP\n",
+      "* Production model solved with objective: 5700\n",
+      "* Total benefit=5700\n",
+      "Production of A: 50.0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cargar los datos y obtener el modelo\n",
+    "from data_and_model_construction.data import create_data_dict\n",
+    "from data_and_model_construction.common_model import create_model, solve_model, print_model\n",
+    "from plot_kind.costo_op_vs_disp import CostoOportunidad\n",
+    "\n",
+    "data = create_data_dict()\n",
+    "mdl, production_vars, products = create_model(data)\n",
+    "solve_model(mdl, production_vars, products)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9545df0d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from plot_kind.costo_op_vs_disp import CostoOportunidad"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6bab410a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Demanda mínima encontrada para el producto B.\n",
+      "[debug] (lower, upper): (80.0, 140.0)\n",
+      "---\n",
+      "- Adjusting RHS to: 79.99\n",
+      "No solution found for RHS value: 79.99\n",
+      "---\n",
+      "- Adjusting RHS to: 140.01\n",
+      "* Production model solved with objective: 8200.5\n",
+      "* Total benefit=8200.5\n",
+      "Production of A: 100.0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 0.01666666666665151\n",
+      "---\n",
+      "- Adjusting RHS to: 172.0\n",
+      "* Production model solved with objective: 9800\n",
+      "* Total benefit=9800\n",
+      "Production of A: 100.0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 53.33333333333334\n",
+      "---\n",
+      "- Adjusting RHS to: 172.01\n",
+      "* Production model solved with objective: 9800.3\n",
+      "* Total benefit=9800.3\n",
+      "Production of A: 99.99000000000001\n",
+      "Production of B: 80.0\n",
+      "Production of C: 53.359999999999985\n",
+      "---\n",
+      "- Adjusting RHS to: 272.0\n",
+      "* Production model solved with objective: 12800\n",
+      "* Total benefit=12800\n",
+      "Production of A: 0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 320.0\n",
+      "---\n",
+      "- Adjusting RHS to: 272.01\n",
+      "* Production model solved with objective: 12800\n",
+      "* Total benefit=12800\n",
+      "Production of A: 0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 320.0\n",
+      "---\n",
+      "- Adjusting RHS to: 110\n",
+      "* Production model solved with objective: 5700\n",
+      "* Total benefit=5700\n",
+      "Production of A: 50.0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Usage of the iterate_over_rhs method, checking whether there exists demmin or not\n",
+    "constraint_nameX = 'Disp_Equipo3'  # The name of the constraint to analyze\n",
+    "product_name=\"B\"\n",
+    "\n",
+    "costo_op = CostoOportunidad(mdl, products, production_vars)\n",
+    "current_rhs_value, rhs_values, dual_values = costo_op.iterate(constraint_nameX, product_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "55b40eb3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[debug] current_x_value: 110\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 2000x1000 with 0 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "costo_op.plot(constraint_nameX, product_name, \"[hs/mes]\", \"[$/un]\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "430c9ef3",
+   "metadata": {},
+   "source": [
+    "### VM"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "704a4419",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model: guia5problematipo2\n",
+      " - number of variables: 3\n",
+      "   - binary=0, integer=0, continuous=3\n",
+      " - number of constraints: 9\n",
+      "   - linear=9\n",
+      " - parameters: defaults\n",
+      " - objective: none\n",
+      " - problem type is: LP\n",
+      "--------------------\n",
+      "Model: guia5problematipo2\n",
+      "Constraints:\n",
+      "   Disp_Equipo1: 0.800A+0.800B+0.300C <= 160\n",
+      "   Disp_Equipo2: 0.600A+1.200B <= 180\n",
+      "   Disp_Equipo3: 0.600A+B+0.600C <= 110\n",
+      "   DemandMax_A: A <= 100\n",
+      "   DemandMax_B: B <= 120\n",
+      "   DemandMin_B: B >= 80\n",
+      "Objective: 50A+40B+30C\n",
+      " Maximize\n",
+      "--------------------\n",
+      "* Production model solved with objective: 5700\n",
+      "* Total benefit=5700\n",
+      "Production of A: 50.0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cargar los datos y obtener el modelo\n",
+    "#from data_and_model_construction.data import create_data_dict\n",
+    "#from data_and_model_construction.common_model import create_model, solve_model, print_model\n",
+    "from plot_kind.vm_vs_disp import VM\n",
+    "\n",
+    "data = create_data_dict()\n",
+    "mdl, production_vars, products = create_model(data)\n",
+    "\n",
+    "print_model(mdl)\n",
+    "solve_model(mdl, production_vars, products)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e60a2f85",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[debug] (lower, upper): (104.0, 1e+20)\n",
+      "---\n",
+      "- Adjusting RHS to: 103.99\n",
+      "* Production model solved with objective: 5699.6\n",
+      "* Total benefit=5699.6\n",
+      "Production of A: 49.97999999999999\n",
+      "Production of B: 80.0\n",
+      "Production of C: 0.020000000000010232\n",
+      "---\n",
+      "- Adjusting RHS to: 79.0\n",
+      "* Production model solved with objective: 4700\n",
+      "* Total benefit=4700\n",
+      "Production of A: 0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 50.0\n",
+      "---\n",
+      "- Adjusting RHS to: 78.99\n",
+      "* Production model solved with objective: 4699\n",
+      "* Total benefit=4699\n",
+      "Production of A: 0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 49.966666666666654\n",
+      "---\n",
+      "- Adjusting RHS to: 64.0\n",
+      "* Production model solved with objective: 3200\n",
+      "* Total benefit=3200\n",
+      "Production of A: 0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 0\n",
+      "---\n",
+      "- Adjusting RHS to: 63.99\n",
+      "No solution found for RHS value: 63.99\n",
+      "---\n",
+      "- Adjusting RHS to: 160\n",
+      "* Production model solved with objective: 5700\n",
+      "* Total benefit=5700\n",
+      "Production of A: 50.0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "from plot_kind.vm_vs_disp import VM\n",
+    "# Usage of the iterate_over_rhs method\n",
+    "constraint_nameX = 'Disp_Equipo1'  # The name of the constraint X to analyze\n",
+    "\n",
+    "vm = VM(mdl, products, production_vars)\n",
+    "current_rhs_value, rhs_values, dual_values = vm.iterate(constraint_nameX)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a5e7b6c5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[debug] current_x_value: 160\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 2000x1000 with 0 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Graficamos\n",
+    "vm.plot(constraint_nameX,\"[hs/mes]\", \"[$/un]\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "64bd8f43",
+   "metadata": {},
+   "source": [
+    "## Funcional"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a4242851",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model: guia5problematipo2\n",
+      " - number of variables: 3\n",
+      "   - binary=0, integer=0, continuous=3\n",
+      " - number of constraints: 9\n",
+      "   - linear=9\n",
+      " - parameters: defaults\n",
+      " - objective: none\n",
+      " - problem type is: LP\n",
+      "* Production model solved with objective: 5700\n",
+      "* Total benefit=5700\n",
+      "Production of A: 50.0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cargar los datos y obtener el modelo\n",
+    "from data_and_model_construction.data import create_data_dict\n",
+    "from data_and_model_construction.common_model import create_model, solve_model\n",
+    "from plot_kind.funcional_vs_disp import Funcional\n",
+    "\n",
+    "data = create_data_dict()\n",
+    "mdl, production_vars, products = create_model(data)\n",
+    "solve_model(mdl, production_vars, products)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cc63805d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "---Initial lower bound: 80.0\n",
+      "---\n",
+      "- Adjusting RHS to: 80.0\n",
+      "* Production model solved with objective: 3200\n",
+      "* Total benefit=3200\n",
+      "Production of A: 0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 0\n",
+      "---Initial upper bound: 140.0\n",
+      "---\n",
+      "- Adjusting RHS to: 140.0\n",
+      "* Production model solved with objective: 8200\n",
+      "* Total benefit=8200\n",
+      "Production of A: 100.0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 0\n",
+      "---\n",
+      "- Adjusting RHS to: 79.99\n",
+      "No solution found for RHS value: 79.99\n",
+      "---\n",
+      "- Adjusting RHS to: 140.01\n",
+      "* Production model solved with objective: 8200.5\n",
+      "* Total benefit=8200.5\n",
+      "Production of A: 100.0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 0.01666666666665151\n",
+      "---\n",
+      "- Adjusting RHS to: 172.0\n",
+      "* Production model solved with objective: 9800\n",
+      "* Total benefit=9800\n",
+      "Production of A: 100.0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 53.33333333333334\n",
+      "---\n",
+      "- Adjusting RHS to: 172.01\n",
+      "* Production model solved with objective: 9800.3\n",
+      "* Total benefit=9800.3\n",
+      "Production of A: 99.99000000000001\n",
+      "Production of B: 80.0\n",
+      "Production of C: 53.359999999999985\n",
+      "---\n",
+      "- Adjusting RHS to: 272.0\n",
+      "* Production model solved with objective: 12800\n",
+      "* Total benefit=12800\n",
+      "Production of A: 0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 320.0\n",
+      "---\n",
+      "- Adjusting RHS to: 272.01\n",
+      "* Production model solved with objective: 12800\n",
+      "* Total benefit=12800\n",
+      "Production of A: 0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 320.0\n",
+      "---\n",
+      "- Adjusting RHS to: 110\n",
+      "* Production model solved with objective: 5700\n",
+      "* Total benefit=5700\n",
+      "Production of A: 50.0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Usage of the iterate_over_rhs method\n",
+    "constraint_name = 'Disp_Equipo3'  # The name of the constraint to analyze\n",
+    "funcional = Funcional(mdl, products, production_vars)\n",
+    "real_rhs_value, rhs_values, objective_values = funcional.iterate(constraint_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "745581ea",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[debug] pairs [(110, 5700.0), (80.0, 3200.0), (140.0, 8200.0), (172.0, 9800.0), (272.0, 12800.0)]\n",
+      "[debug] pairs [(80.0, 3200.0), (110, 5700.0), (140.0, 8200.0), (172.0, 9800.0), (272.0, 12800.0)]\n",
+      "[debug] new_rhs [80.0, 110, 140.0, 172.0, 272.0]\n",
+      "[debug] new_dual [3200.0, 5700.0, 8200.0, 9800.0, 12800.0]\n",
+      "[debug] current_x_value: 110\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 2000x1000 with 0 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "funcional.plot(constraint_name, \"[hs/mes]\", \"[$/mes]\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "68a52f13",
+   "metadata": {},
+   "source": [
+    "## Curva de oferta"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "feeb1fd5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model: guia5problematipo2\n",
+      " - number of variables: 3\n",
+      "   - binary=0, integer=0, continuous=3\n",
+      " - number of constraints: 9\n",
+      "   - linear=9\n",
+      " - parameters: defaults\n",
+      " - objective: none\n",
+      " - problem type is: LP\n",
+      "* Production model solved with objective: 5700\n",
+      "* Total benefit=5700\n",
+      "Production of A: 50.0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cargar los datos y obtener el modelo\n",
+    "from data_and_model_construction.data import create_data_dict\n",
+    "from data_and_model_construction.common_model import create_model, solve_model\n",
+    "from plot_kind.curva_of_cant_vs_precio import CurvaDeOferta\n",
+    "\n",
+    "data = create_data_dict()\n",
+    "mdl, production_vars, products = create_model(data)\n",
+    "solve_model(mdl, production_vars, products)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fc4ac4c0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[debug] (lower, upper): (-1e+20, 83.33333333333334)\n",
+      "* Production model solved with objective: 9167.77\n",
+      "* Total benefit=9167.77\n",
+      "Production of A: 0\n",
+      "Production of B: 110.0\n",
+      "Production of C: 0\n",
+      "* Production model solved with objective: 2500\n",
+      "* Total benefit=2500\n",
+      "Production of A: 50.0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 0\n",
+      "* Production model solved with objective: 5700\n",
+      "* Total benefit=5700\n",
+      "Production of A: 50.0\n",
+      "Production of B: 80.0\n",
+      "Production of C: 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "from plot_kind.curva_of_cant_vs_precio import CurvaDeOferta\n",
+    "product_name = \"B\"\n",
+    "curva_of = CurvaDeOferta(mdl, products, production_vars)\n",
+    "current_price_value, prices, quantities = curva_of.iterate(product_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "737435fd",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[debug] current_x_value: 40\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 2000x1000 with 0 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "curva_of.plot(product_name, \"[$/u]\", \"[u/mes]\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/ALL IN ONE USAGE EXAMPLE Problema5tipo2.ipynb
+++ b/src/ALL IN ONE USAGE EXAMPLE Problema5tipo2.ipynb
@@ -2,16 +2,16 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "4c82064c",
+   "id": "884abf59",
    "metadata": {},
    "source": [
-    "## Costo oportunidad"
+    "## Carga de datos y creación del modelo"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5f64678b",
+   "id": "edf96648",
    "metadata": {},
    "outputs": [
     {
@@ -38,11 +38,18 @@
     "# Cargar los datos y obtener el modelo\n",
     "from data_and_model_construction.data import create_data_dict\n",
     "from data_and_model_construction.common_model import create_model, solve_model, print_model\n",
-    "from plot_kind.costo_op_vs_disp import CostoOportunidad\n",
     "\n",
     "data = create_data_dict()\n",
     "mdl, production_vars, products = create_model(data)\n",
-    "solve_model(mdl, production_vars, products)\n"
+    "solve_model(mdl, production_vars, products)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4c82064c",
+   "metadata": {},
+   "source": [
+    "## Costo oportunidad"
    ]
   },
   {
@@ -65,7 +72,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Demanda mínima encontrada para el producto B.\n",
+      "Demanda mínima encontrada para el producto B.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "[debug] (lower, upper): (80.0, 140.0)\n",
       "---\n",
       "- Adjusting RHS to: 79.99\n",
@@ -165,58 +178,7 @@
    "id": "430c9ef3",
    "metadata": {},
    "source": [
-    "### VM"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "704a4419",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Model: guia5problematipo2\n",
-      " - number of variables: 3\n",
-      "   - binary=0, integer=0, continuous=3\n",
-      " - number of constraints: 9\n",
-      "   - linear=9\n",
-      " - parameters: defaults\n",
-      " - objective: none\n",
-      " - problem type is: LP\n",
-      "--------------------\n",
-      "Model: guia5problematipo2\n",
-      "Constraints:\n",
-      "   Disp_Equipo1: 0.800A+0.800B+0.300C <= 160\n",
-      "   Disp_Equipo2: 0.600A+1.200B <= 180\n",
-      "   Disp_Equipo3: 0.600A+B+0.600C <= 110\n",
-      "   DemandMax_A: A <= 100\n",
-      "   DemandMax_B: B <= 120\n",
-      "   DemandMin_B: B >= 80\n",
-      "Objective: 50A+40B+30C\n",
-      " Maximize\n",
-      "--------------------\n",
-      "* Production model solved with objective: 5700\n",
-      "* Total benefit=5700\n",
-      "Production of A: 50.0\n",
-      "Production of B: 80.0\n",
-      "Production of C: 0\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Cargar los datos y obtener el modelo\n",
-    "#from data_and_model_construction.data import create_data_dict\n",
-    "#from data_and_model_construction.common_model import create_model, solve_model, print_model\n",
-    "from plot_kind.vm_vs_disp import VM\n",
-    "\n",
-    "data = create_data_dict()\n",
-    "mdl, production_vars, products = create_model(data)\n",
-    "\n",
-    "print_model(mdl)\n",
-    "solve_model(mdl, production_vars, products)"
+    "## Valor Marginal"
    ]
   },
   {
@@ -328,43 +290,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a4242851",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Model: guia5problematipo2\n",
-      " - number of variables: 3\n",
-      "   - binary=0, integer=0, continuous=3\n",
-      " - number of constraints: 9\n",
-      "   - linear=9\n",
-      " - parameters: defaults\n",
-      " - objective: none\n",
-      " - problem type is: LP\n",
-      "* Production model solved with objective: 5700\n",
-      "* Total benefit=5700\n",
-      "Production of A: 50.0\n",
-      "Production of B: 80.0\n",
-      "Production of C: 0\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Cargar los datos y obtener el modelo\n",
-    "from data_and_model_construction.data import create_data_dict\n",
-    "from data_and_model_construction.common_model import create_model, solve_model\n",
-    "from plot_kind.funcional_vs_disp import Funcional\n",
-    "\n",
-    "data = create_data_dict()\n",
-    "mdl, production_vars, products = create_model(data)\n",
-    "solve_model(mdl, production_vars, products)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "cc63805d",
    "metadata": {},
    "outputs": [
@@ -437,6 +362,7 @@
     }
    ],
    "source": [
+    "from plot_kind.funcional_vs_disp import Funcional\n",
     "# Usage of the iterate_over_rhs method\n",
     "constraint_name = 'Disp_Equipo3'  # The name of the constraint to analyze\n",
     "funcional = Funcional(mdl, products, production_vars)\n",
@@ -489,43 +415,6 @@
    "metadata": {},
    "source": [
     "## Curva de oferta"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "feeb1fd5",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Model: guia5problematipo2\n",
-      " - number of variables: 3\n",
-      "   - binary=0, integer=0, continuous=3\n",
-      " - number of constraints: 9\n",
-      "   - linear=9\n",
-      " - parameters: defaults\n",
-      " - objective: none\n",
-      " - problem type is: LP\n",
-      "* Production model solved with objective: 5700\n",
-      "* Total benefit=5700\n",
-      "Production of A: 50.0\n",
-      "Production of B: 80.0\n",
-      "Production of C: 0\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Cargar los datos y obtener el modelo\n",
-    "from data_and_model_construction.data import create_data_dict\n",
-    "from data_and_model_construction.common_model import create_model, solve_model\n",
-    "from plot_kind.curva_of_cant_vs_precio import CurvaDeOferta\n",
-    "\n",
-    "data = create_data_dict()\n",
-    "mdl, production_vars, products = create_model(data)\n",
-    "solve_model(mdl, production_vars, products)"
    ]
   },
   {

--- a/src/ALL IN ONE USAGE EXAMPLE Problema5tipo2.ipynb
+++ b/src/ALL IN ONE USAGE EXAMPLE Problema5tipo2.ipynb
@@ -769,13 +769,13 @@
        " [5700.0, 3200.0, 8200.0, 9800.0, 12800.0])"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "pko.funcional('Disp_Equipo3', \"[hs/mes]\", \"[$/mes]\")"
+    "pko.funcional(\"Disp_Equipo3\", \"[hs/mes]\", \"[$/mes]\")"
    ]
   },
   {
@@ -877,13 +877,13 @@
        "  40.0])"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "pko.costo_oportunidad('Disp_Equipo3', \"B\", \"[hs/mes]\", \"[$/un]\")"
+    "pko.costo_oportunidad(\"B\", \"Disp_Equipo3\", \"[hs/mes]\", \"[$/un]\")"
    ]
   },
   {
@@ -978,13 +978,13 @@
        "  0])"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "pko.vm('Disp_Equipo3', \"[hs/mes]\", \"[$/un]\")"
+    "pko.vm(\"Disp_Equipo3\", \"[hs/mes]\", \"[$/un]\")"
    ]
   }
  ],

--- a/src/ALL IN ONE USAGE EXAMPLE Problema5tipo2.ipynb
+++ b/src/ALL IN ONE USAGE EXAMPLE Problema5tipo2.ipynb
@@ -497,6 +497,41 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "95ff856c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ### AUX\n",
+    "# product_name = \"B\"\n",
+    "# curva_of = CurvaDeOferta(mdl, products, production_vars)\n",
+    "# current_price_value, prices, quantities = curva_of.iterate(product_name)\n",
+    "# curva_of.plot(product_name, \"[$/u]\", \"[u/mes]\")\n",
+    "\n",
+    "# ### AUX\n",
+    "# constraint_name = 'Disp_Equipo3'  # The name of the constraint to analyze\n",
+    "# funcional = Funcional(mdl, products, production_vars)\n",
+    "# real_rhs_value, rhs_values, objective_values = funcional.iterate(constraint_name)\n",
+    "# funcional.plot(constraint_name, \"[hs/mes]\", \"[$/mes]\")\n",
+    "\n",
+    "# ### AUX\n",
+    "# constraint_nameX = 'Disp_Equipo3'  # The name of the constraint to analyze\n",
+    "# product_name=\"B\"\n",
+    "\n",
+    "# costo_op = CostoOportunidad(mdl, products, production_vars)\n",
+    "# current_rhs_value, rhs_values, dual_values = costo_op.iterate(constraint_nameX, product_name)\n",
+    "# costo_op.plot(constraint_nameX, product_name, \"[hs/mes]\", \"[$/un]\")\n",
+    "\n",
+    "# ### AUX\n",
+    "# constraint_nameX = 'Disp_Equipo1'  # The name of the constraint X to analyze\n",
+    "\n",
+    "# vm = VM(mdl, products, production_vars)\n",
+    "# current_rhs_value, rhs_values, dual_values = vm.iterate(constraint_nameX)\n",
+    "# vm.plot(constraint_nameX,\"[hs/mes]\", \"[$/un]\")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "ae976daf",
    "metadata": {},
@@ -551,55 +586,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "95ff856c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# ### AUX\n",
-    "# product_name = \"B\"\n",
-    "# curva_of = CurvaDeOferta(mdl, products, production_vars)\n",
-    "# current_price_value, prices, quantities = curva_of.iterate(product_name)\n",
-    "# curva_of.plot(product_name, \"[$/u]\", \"[u/mes]\")\n",
-    "\n",
-    "# ### AUX\n",
-    "# constraint_name = 'Disp_Equipo3'  # The name of the constraint to analyze\n",
-    "# funcional = Funcional(mdl, products, production_vars)\n",
-    "# real_rhs_value, rhs_values, objective_values = funcional.iterate(constraint_name)\n",
-    "# funcional.plot(constraint_name, \"[hs/mes]\", \"[$/mes]\")\n",
-    "\n",
-    "# ### AUX\n",
-    "# constraint_nameX = 'Disp_Equipo3'  # The name of the constraint to analyze\n",
-    "# product_name=\"B\"\n",
-    "\n",
-    "# costo_op = CostoOportunidad(mdl, products, production_vars)\n",
-    "# current_rhs_value, rhs_values, dual_values = costo_op.iterate(constraint_nameX, product_name)\n",
-    "# costo_op.plot(constraint_nameX, product_name, \"[hs/mes]\", \"[$/un]\")\n",
-    "\n",
-    "# ### AUX\n",
-    "# constraint_nameX = 'Disp_Equipo1'  # The name of the constraint X to analyze\n",
-    "\n",
-    "# vm = VM(mdl, products, production_vars)\n",
-    "# current_rhs_value, rhs_values, dual_values = vm.iterate(constraint_nameX)\n",
-    "# vm.plot(constraint_nameX,\"[hs/mes]\", \"[$/un]\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "de6ac910",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from plot_kind.plot_kind_orchestrator import PlotKindOrchestrator"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d0ed38c7",
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "from plot_kind.plot_kind_orchestrator import PlotKindOrchestrator\n",
+    "\n",
     "pko = PlotKindOrchestrator(mdl, products, production_vars)"
    ]
   },
@@ -644,19 +636,10 @@
     {
      "data": {
       "text/plain": [
-       "<Figure size 2000x1000 with 0 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
        "(50, [0, 29.999999999999993, 29.999999999999993, 50], [0, 0, 50.0, 50.0])"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -755,21 +738,12 @@
     {
      "data": {
       "text/plain": [
-       "<Figure size 2000x1000 with 0 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
        "(110,\n",
        " [110, 80.0, 140.0, 172.0, 272.0],\n",
        " [5700.0, 3200.0, 8200.0, 9800.0, 12800.0])"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -788,13 +762,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Demanda mínima encontrada para el producto B.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Demanda mínima encontrada para el producto B.\n",
       "[debug] (lower, upper): (80.0, 140.0)\n",
       "---\n",
       "- Adjusting RHS to: 79.99\n",
@@ -856,15 +824,6 @@
     {
      "data": {
       "text/plain": [
-       "<Figure size 2000x1000 with 0 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
        "(110,\n",
        " [80.0, 110, 140.0, 140.0, 172.0, 172.0, 272.0, 272.0],\n",
        " [43.33333333333334,\n",
@@ -877,7 +836,7 @@
        "  40.0])"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -957,15 +916,6 @@
     {
      "data": {
       "text/plain": [
-       "<Figure size 2000x1000 with 0 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
        "(110,\n",
        " [80.0, 110, 140.0, 140.0, 172.0, 172.0, 272.0, 272.0],\n",
        " [83.33333333333334,\n",
@@ -978,7 +928,7 @@
        "  0])"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/src/iterators/common_iterator.py
+++ b/src/iterators/common_iterator.py
@@ -53,7 +53,7 @@ class Iterator(ABC):
         # Increase x_coord starting from upper bound + m
         right_x_list, right_y_list = self.iterate_right(initial_upper, mdl, constraint_nameX, constraint_nameY, get_y_function)
         x_values.extend(right_x_list)
-        y_values.extend(right_y_list)
+        y_values.extend(right_y_list)        
         
         # Devuelvo el current y las listas
         return current_x_value, x_values, y_values

--- a/src/iterators/rhs_iterator.py
+++ b/src/iterators/rhs_iterator.py
@@ -81,4 +81,3 @@ class RhsIterator(Iterator):
         self.reestablish_initial_value(current_rhs_value, mdl)
         
         return iteration_results
-        # (Aux: podría usar los self.c_nX y c_nY en lugar de recibirlos).

--- a/src/iterators/rhs_iterator.py
+++ b/src/iterators/rhs_iterator.py
@@ -54,6 +54,10 @@ class RhsIterator(Iterator):
             print("No solution found for RHS value: {0}".format(rhs_value))
             return None  # Return None to indicate that the model is infeasible at this point
 
+    # Deja el mdl como estaba antes de ser modificado por el proceso de iteración.
+    def reestablish_initial_value(self, current_rhs_value, mdl):
+        self.solve(current_rhs_value, mdl)
+
     # Pre: se resolvió el modelo y existe solución.
     # Itera sobre el rhs de la restricción constraint_nameX.
     def iterate_over_rhs(self, mdl, get_y_function):
@@ -70,6 +74,11 @@ class RhsIterator(Iterator):
         # Obtengo punto actual
         current_rhs_value = c.rhs.constant
         current_dual_value = get_y_function(self.constraint_nameY)
+
+        iteration_results = super().iterate_internal(self.constraint_nameX, self.constraint_nameY, current_rhs_value, current_dual_value, mdl, get_y_function)
+
+        # Restablezco el valor original, que fue modificado por solve durante la iteración
+        self.reestablish_initial_value(current_rhs_value, mdl)
         
-        return super().iterate_internal(self.constraint_nameX, self.constraint_nameY, current_rhs_value, current_dual_value, mdl, get_y_function)
+        return iteration_results
         # (Aux: podría usar los self.c_nX y c_nY en lugar de recibirlos).

--- a/src/plot_kind/curva_of_cant_vs_precio.py
+++ b/src/plot_kind/curva_of_cant_vs_precio.py
@@ -44,15 +44,7 @@ class CurvaDeOferta(PlotKind):
         iterator = PriceIterator(product_name, products, production_vars)
         current_price_value, prices, quantities = iterator.iterate_over_price(mdl, self.get_y)
         
-        # Le agregamos el punto de x=0 al inicio, porque la función que itera solo contempla números no negativos
-        # AUX: esto puede ir adentro de iterator []    
-        price = 0     
-        _ = iterator.solve(price, mdl)
-        quantity = self.get_y(prod_var)
-        x_values = [price] + prices
-        y_values = [quantity] + quantities
-
-        return current_price_value, x_values, y_values
+        return current_price_value, prices, quantities
 
 
 ### Comentarios de debug, entre iterate y plot

--- a/src/plot_kind/funcional_vs_disp.py
+++ b/src/plot_kind/funcional_vs_disp.py
@@ -36,6 +36,10 @@ class Funcional(PlotKind):
 
     
     def iterate(self, constraint_name):
+        # Aux, inicializaciones de listas solo necesarias acá hasta que se refactorice
+        rhs_values.clear()
+        objective_values.clear()
+
         self.current_rhs_value, self.rhs_values, self.objective_values = iterate_over_rhs(constraint_name, self.mdl, self.products, self.production_vars)
 
         return self.current_rhs_value, self.rhs_values, self.objective_values # currently returned for debugging purposes
@@ -189,8 +193,16 @@ def iterate_over_rhs(constraint_name, mdl, products, production_vars):
                         rhs = new_upper + m
 
                         break
+
+    # Restablezco el valor original, que fue modificado por solve durante la iteración
+    reestablish_initial_value(c, real_rhs_value, mdl, products, production_vars)
                     
     return real_rhs_value, rhs_values, objective_values
+
+# Restablezco el valor original, que fue modificado por solve durante la iteración
+# Aux: Esto está acá temporalmente, hasta que se refactorice este archivo, xq actualmente no usa el rhs_iterator.
+def reestablish_initial_value(c, real_rhs_value, mdl, products, production_vars):
+    _ = solve(c, real_rhs_value, mdl, products, production_vars)
 
 # Llamar a esta función es necesario, dsp de llamar a iterate
 # y antes de llamar a plot, porque estamos usando la versión anterior

--- a/src/plot_kind/plot_kind_orchestrator.py
+++ b/src/plot_kind/plot_kind_orchestrator.py
@@ -1,0 +1,36 @@
+from plot_kind.costo_op_vs_disp import CostoOportunidad
+from plot_kind.curva_of_cant_vs_precio import CurvaDeOferta
+from plot_kind.funcional_vs_disp import Funcional
+from plot_kind.vm_vs_disp import VM
+
+class PlotKindOrchestrator:
+    # Recibe: mdl, el modelo creado y resuelto; products y production_vars, variables creadas con los datos del modelo.
+    def __init__(self, mdl, products, production_vars):
+        self.mdl = mdl
+        self.products = products
+        self.production_vars = production_vars
+    
+    def vm(self, constraint_nameX, x_unit, y_unit):
+        vm = VM(self.mdl, self.products, self.production_vars)
+        current_rhs_value, rhs_values, dual_values = vm.iterate(constraint_nameX) # Aux returned for debugging purposes only
+        vm.plot(constraint_nameX, x_unit, y_unit)
+        return current_rhs_value, rhs_values, dual_values #
+    
+    def costo_oportunidad(self, constraint_nameX, product_name, x_unit, y_unit):
+        costo_op = CostoOportunidad(self.mdl, self.products, self.production_vars)
+        current_rhs_value, rhs_values, dual_values = costo_op.iterate(constraint_nameX, product_name)
+        costo_op.plot(constraint_nameX, product_name, x_unit, y_unit)
+        return current_rhs_value, rhs_values, dual_values 
+    
+    def funcional(self,constraint_nameX, x_unit, y_unit):
+        funcional = Funcional(self.mdl, self.products, self.production_vars)
+        real_rhs_value, rhs_values, objective_values = funcional.iterate(constraint_nameX)
+        funcional.plot(constraint_nameX, x_unit, y_unit) #"[hs/mes]", "[$/mes]")
+        return real_rhs_value, rhs_values, objective_values
+    
+    def curva_de_oferta(self, product_name, x_unit, y_unit):
+        curva_of = CurvaDeOferta(self.mdl, self.products, self.production_vars)
+        current_price_value, prices, quantities = curva_of.iterate(product_name)
+        curva_of.plot(product_name, x_unit, y_unit)
+        return current_price_value, prices, quantities 
+

--- a/src/plot_kind/plot_kind_orchestrator.py
+++ b/src/plot_kind/plot_kind_orchestrator.py
@@ -16,7 +16,7 @@ class PlotKindOrchestrator:
         vm.plot(constraint_nameX, x_unit, y_unit)
         return current_rhs_value, rhs_values, dual_values #
     
-    def costo_oportunidad(self, constraint_nameX, product_name, x_unit, y_unit):
+    def costo_oportunidad(self, product_name, constraint_nameX, x_unit, y_unit):
         costo_op = CostoOportunidad(self.mdl, self.products, self.production_vars)
         current_rhs_value, rhs_values, dual_values = costo_op.iterate(constraint_nameX, product_name)
         costo_op.plot(constraint_nameX, product_name, x_unit, y_unit)

--- a/src/plot_kind_plotter.py
+++ b/src/plot_kind_plotter.py
@@ -16,6 +16,7 @@ def plot(x_values, y_values, current_x_value, text, is_function_discontinuous=Tr
     # Set default font size for all text elements
     plt.rcParams.update({'font.size': 18})
     WIDTH=6
+    #plt.figure(figsize=(20, 10)) # si se desea usar, debe ir acá arriba, antes de que plt.otras_cosas dibujen sobre la figura
     
     if is_function_discontinuous:
         # Dibujar líneas horizontales entre x y x+1, con valor y
@@ -61,5 +62,4 @@ def plot(x_values, y_values, current_x_value, text, is_function_discontinuous=Tr
     # Mostrar yticks desde el 0, por claridad
     plt.ylim(bottom=-1)         
 
-    plt.figure(figsize=(20, 10))
     plt.show()


### PR DESCRIPTION
# Creación de un Orchestrator que internamente llama a las demás clases, para simplificar el uso

- **Se restablece el rhs o price original que el modelo tenía antes de iterar**, al terminar las iteraciones. Anteriormente esto no se hacía, y eso causaba que el `mdl` quedara modificado después de llamar a una `iterate()`, y había que volver a crear y resolver el modelo desde cero para usar otro tipo de gráfico. Con este cambio **ya no es necesario recrear el `mdl` cada vez** que se lo quiere usar, y **se puede ejecutar secuencialmente los cuatro tipos de gráfico, repetidas veces y en cualquier orden**, y el resultado sigue siendo el correcto.


- **Se crea el `PlotKindOrchestrator` con métodos que internamente crean y llaman a los de `VM()` ,`CostoOp()` etc.** Esto **simplifica significativamente el uso**. Ya no es necesario crear objetos de las clases `VM()`, `CostoOp()`, etc, y llamar varios métodos suyos; ahora **solamente alcanza con crear e interactuar con un orchestrator** con líneas como:
      - `pko.vm("Disp_Equipo3", "[hs/mes]", "[$/un]")`
      - `pko.costo_oportunidad("B", "Disp_Equipo3", "[hs/mes]", "[$/un]")`
      - y similar para los otros dos tipos de gráfico.
- **Se agrega notebook `All in one usage example`** en el que se muestra que ahora se puede ejecutar todo desde un mismo notebook, y utilizando simplemente el `PlotKindOrchestrator`.


- **Fix bug silencioso en el plotter.** La ubicación de la línea plt.figure() estaba generando una segunda figura vacía, solo funcionaba por acciones de Jupyter/IDE pero era incorrecto. Solucionado.